### PR TITLE
Fix async writes and CLI error handling

### DIFF
--- a/bin/servergen.js
+++ b/bin/servergen.js
@@ -27,32 +27,41 @@ const templatesDirExpress = path.join(__dirname, "..", "templates", "express");
 const templatesDirNode = path.join(__dirname, "..", "templates", "node");
 const viewsDir = path.join(__dirname, "..", "templates", "express", "views");
 
-// Create Directory with the App Name
-fs_helper.buildFolderforApp(folderDir);
+try {
+  // Create Directory with the App Name
+  fs_helper.buildFolderforApp(folderDir);
 
-options.framework == "node"
-  ? file_creator.createNodeApp(
+  if (options.framework === "node") {
+    file_creator.createNodeApp(
       templatesDirNode,
       folderDir,
       appName,
       options.view,
       options.Db
-    )
-  : file_creator.createExpressApp(
+    );
+  } else {
+    file_creator.createExpressApp(
       templatesDirExpress,
       folderDir,
       appName,
       options.view,
       options.Db
     );
+  }
 
-// Handle View Flag
-file_creator.handleViews(folderDir, viewsDir, options.view)
+  // Handle View Flag
+  file_creator.handleViews(folderDir, viewsDir, options.view);
 
-options.Db ? file_creator.handleConfig(folderDir, templatesDirExpress) : null;
+  if (options.Db) {
+    file_creator.handleConfig(folderDir, templatesDirExpress);
+  }
 
-file_creator.addGitIgnore(folderDir, templatesDirExpress);
-file_creator.addDockerSupport(folderDir, templatesDirExpress);
+  file_creator.addGitIgnore(folderDir, templatesDirExpress);
+  file_creator.addDockerSupport(folderDir, templatesDirExpress);
+} catch (err) {
+  console.error(chalk.red("Error: " + err.message));
+  process.exit(1);
+}
 
 displayer.beginMessage(appName);
 console.log("Installing required NPM Packages. This might take a while.");
@@ -66,4 +75,5 @@ execPromise(`cd ${folderDir} && npm install`)
   })
   .catch(err => {
     console.log(chalk.red("\nError: " + err));
-});
+    process.exit(1);
+  });

--- a/lib/file_generator.js
+++ b/lib/file_generator.js
@@ -54,10 +54,15 @@ const generatePackage4Express = function (folderDir, appName, view, config) {
   if (config) {
     pkg["dependencies"]["mongoose"] = "^5.11.12";
   }
-  fs.writeFile(
-    path.join(folderDir, "package.json"),
-    JSON.stringify(pkg, null, 2) + "\n"
-  );
+  try {
+    fs.writeFileSync(
+      path.join(folderDir, "package.json"),
+      JSON.stringify(pkg, null, 2) + "\n"
+    );
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
 };
 
 const generatePackage4Node = function (folderDir, appName, view, config) {
@@ -93,10 +98,15 @@ const generatePackage4Node = function (folderDir, appName, view, config) {
   if (config) {
     pkg["dependencies"]["mongoose"] = "^5.11.12";
   }
-  fs.writeFile(
-    path.join(folderDir, "package.json"),
-    JSON.stringify(pkg, null, 2) + "\n"
-  );
+  try {
+    fs.writeFileSync(
+      path.join(folderDir, "package.json"),
+      JSON.stringify(pkg, null, 2) + "\n"
+    );
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
 };
 
 const createExpressApp = function (
@@ -173,20 +183,16 @@ const handleViews = function (folderDir, viewsDir, view) {
 const manageViews = function (path1, view_name, addView) {
   const view_string = `app.set('view engine','${view_name}') \n app.set('views', path.join(__dirname, 'views'));`;
   const jsFile = path.join(path1, "index.js");
-  fs.readFile(jsFile, "utf8", function (err, data) {
-    if (err) {
-      return console.log(err);
-    }
-    // Replace comment
-    if(addView){
-      var result = data.replace("// Views", view_string);
-    }else{
-      var result = data.replace("// Views", "");
-    }
-    fs.writeFile(jsFile, result, "utf8", function (err) {
-      if (err) return console.log(err);
-    });
-  });
+  try {
+    const data = fs.readFileSync(jsFile, "utf8");
+    const result = addView
+      ? data.replace("// Views", view_string)
+      : data.replace("// Views", "");
+    fs.writeFileSync(jsFile, result, "utf8");
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
 };
 
 


### PR DESCRIPTION
## Summary
- switch file writes in `file_generator.js` to sync versions
- improve `manageViews` to use sync read/write
- wrap server generator steps in try/catch
- exit process when npm install fails
- use strict equality for framework option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68597c3c0a30832192f3666f93467e3b