### PR TITLE
Fix generated-app correctness, harden the CLI, and refresh dependencies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at . All
+reported by contacting the project team at keshavaarav22@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# ServerX Contribution Guide
+# ServerGen Contribution Guide
 
 The goal of this document is to create a contribution process that:
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ Usage: `servergen [options]`
   -V, --version           output the version number
   -f, --framework <type>  Enter Name of Framework: Node | Express
   -n, --name <type>       Enter Name of App
-  -v --view <type>        Name of View Engine: Pug | Jade | EJS | HBS
+  -v, --view <type>       Name of View Engine: Pug | EJS | HBS
+  -p, --port <number>     Set the port for the generated app (default: 3000)
   --db                    Install Mongoose & the Folder Directory for it
+  --skip-install          Skip the npm install step
+  --debug                 Enable debug logging
   -h, --help              display help for command
 ```
 

--- a/bin/servergen.js
+++ b/bin/servergen.js
@@ -29,7 +29,7 @@ program
   .version(pkg.version)
   .option('-f, --framework <type>', 'Enter Name of Framework: Node | Express')
   .requiredOption('-n, --name <type>', 'Enter Name of App')
-  .option('-v --view <type>', 'Name of View Engine: Pug | Jade | EJS | HBS')
+  .option('-v, --view <type>', 'Name of View Engine: Pug | EJS | HBS')
   .option('--db', 'Install Mongoose & the Folder Directory for it')
   .option('-p, --port <number>', 'Set default port for the app', '3000')
   .option('--skip-install', 'Skip npm install step')
@@ -48,6 +48,14 @@ const validationResult = validateOptions(options, config.validation);
 handleValidationErrors(validationResult);
 
 const appName = fileName.cleanAppName(options.name);
+
+if (!appName) {
+  logger.error(
+    'App name must contain at least one alphanumeric character. Please provide a valid name.'
+  );
+  process.exit(1);
+}
+
 const port = parseInt(options.port, 10) || 3000;
 const skipInstall = options.skipInstall || false;
 

--- a/lib/app_generator.js
+++ b/lib/app_generator.js
@@ -4,13 +4,10 @@
  */
 
 import path from 'path';
-import { exec } from 'child_process';
-import util from 'util';
+import { spawn } from 'child_process';
 import fs from 'fs-extra';
 import chalk from 'chalk';
 import { handleError } from './error_handler.js';
-
-const execPromise = util.promisify(exec);
 
 /**
  * AppGenerator class that handles the complete app generation workflow.
@@ -173,13 +170,39 @@ class AppGenerator {
     console.log('Installing required NPM Packages. This might take a while.');
 
     try {
-      await execPromise(`cd ${this.folderDir} && npm install`);
+      await this.runNpmInstall();
       console.log(chalk.green('\nNPM Packages Installed Successfully'));
       this.displayer.endMessage(this.appName);
     } catch (err) {
       handleError(err, 'Failed to install dependencies');
       throw err;
     }
+  }
+
+  /**
+   * Runs `npm install` in the generated app directory.
+   * Uses spawn with the cwd option (no shell) so the target path is never
+   * interpolated into a shell command, which avoids command injection and
+   * correctly handles paths containing spaces.
+   * @returns {Promise<void>}
+   */
+  runNpmInstall() {
+    const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    return new Promise((resolve, reject) => {
+      const child = spawn(npmCmd, ['install'], {
+        cwd: this.folderDir,
+        stdio: 'inherit',
+        shell: false,
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`npm install exited with code ${code}`));
+        }
+      });
+    });
   }
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,7 +23,7 @@ export const getConfig = (baseDir, cwd) => {
     },
     validation: {
       frameworks: ['node', 'express'],
-      views: ['ejs', 'jade', 'pug', 'hbs'],
+      views: ['ejs', 'pug', 'hbs'],
     },
     defaults: {
       framework: 'express',

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,9 +20,9 @@ export const LOG_LEVELS = {
  * @constant {Object.<string, string>}
  */
 export const VIEW_ENGINES = {
-  ejs: '^3.1.10',
-  pug: '^3.0.3',
-  hbs: '^4.2.0',
+  ejs: '^6.0.1',
+  pug: '^3.0.4',
+  hbs: '^4.2.1',
 };
 
 /**
@@ -36,8 +36,8 @@ export const VALID_VIEWS = Object.keys(VIEW_ENGINES);
  * @constant {Object.<string, string>}
  */
 export const DEPENDENCY_VERSIONS = {
-  nodemon: '^3.1.0',
-  cors: '^2.8.5',
-  express: '^4.21.0',
-  mongoose: '^8.5.0',
+  nodemon: '^3.1.14',
+  cors: '^2.8.6',
+  express: '^5.2.1',
+  mongoose: '^9.7.0',
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,7 +21,6 @@ export const LOG_LEVELS = {
  */
 export const VIEW_ENGINES = {
   ejs: '^3.1.10',
-  jade: '^1.11.0',
   pug: '^3.0.3',
   hbs: '^4.2.0',
 };

--- a/lib/file_generator.js
+++ b/lib/file_generator.js
@@ -35,7 +35,7 @@ const generateMVC = (folderDir, templatesDir) => {
  * Generates package.json with appropriate dependencies.
  * @param {string} folderDir - The application directory path.
  * @param {string} appName - The application name.
- * @param {string|null} view - The view engine name (ejs, pug, jade, hbs).
+ * @param {string|null} view - The view engine name (ejs, pug, hbs).
  * @param {boolean} config - Whether to include mongoose configuration.
  * @param {string} framework - The framework type ('node' or 'express').
  */
@@ -46,11 +46,14 @@ const generatePackage = (folderDir, appName, view, config, framework) => {
     description: '',
     main: 'index.js',
     scripts: {
-      start: 'nodemon index.js',
+      start: 'node index.js',
+      dev: 'nodemon index.js',
     },
     dependencies: {
-      nodemon: DEPENDENCY_VERSIONS.nodemon,
       cors: DEPENDENCY_VERSIONS.cors,
+    },
+    devDependencies: {
+      nodemon: DEPENDENCY_VERSIONS.nodemon,
     },
   };
 
@@ -108,7 +111,7 @@ const createNodeApp = (templatesDir, folderDir, appName, view, config) => {
  * Handles view engine setup for the application.
  * @param {string} folderDir - The application directory path.
  * @param {string} viewsDir - Path to view templates.
- * @param {string|null} view - The view engine name (ejs, pug, jade, hbs).
+ * @param {string|null} view - The view engine name (ejs, pug, hbs).
  */
 const handleViews = (folderDir, viewsDir, view) => {
   fs_helper.createDir(folderDir, 'views');

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -24,6 +24,13 @@ export const validateOptions = (options, validationRules) => {
     errors.push(`Invalid view engine: ${options.view}. Valid options: ${validationRules.views.join(', ')}`);
   }
 
+  if (options.port !== undefined && options.port !== null) {
+    const portNum = Number(options.port);
+    if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+      errors.push(`Invalid port: ${options.port}. Port must be an integer between 1 and 65535.`);
+    }
+  }
+
   return {
     isValid: errors.length === 0,
     errors,

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   },
   "homepage": "https://github.com/theinfosecguy/ServerGen#readme",
   "dependencies": {
-    "chalk": "^5.4.1",
+    "chalk": "^5.6.2",
     "commander": "^14.0.2",
-    "fs-extra": "^11.3.3"
+    "fs-extra": "^11.3.5"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.0.18",
-    "vitest": "^4.0.18"
+    "@vitest/coverage-v8": "^4.1.8",
+    "vitest": "^4.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/theinfosecguy/servergen.git"
+    "url": "git+https://github.com/theinfosecguy/ServerGen.git"
   },
   "keywords": [
     "node",
@@ -35,9 +35,9 @@
   "preferGlobal": true,
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/theinfosecguy/servergen/issues"
+    "url": "https://github.com/theinfosecguy/ServerGen/issues"
   },
-  "homepage": "https://github.com/theinfosecguy/servergen#readme",
+  "homepage": "https://github.com/theinfosecguy/ServerGen#readme",
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "description": "Tool to create Node/Express Environment setup within minutes.",
   "type": "module",
-  "main": "./bin/servergen.js",
+  "main": "./index.js",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Tool to create Node/Express Environment setup within minutes.",
   "type": "module",
   "main": "./index.js",
+  "files": [
+    "bin",
+    "lib",
+    "index.js",
+    "templates",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
@@ -11,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/theinfosecguy/ServerGen.git"
+    "url": "git+https://github.com/theinfosecguy/servergen.git"
   },
   "keywords": [
     "node",
@@ -27,15 +35,16 @@
   "preferGlobal": true,
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/theinfosecguy/ServerGen/issues"
+    "url": "https://github.com/theinfosecguy/servergen/issues"
   },
-  "homepage": "https://github.com/theinfosecguy/ServerGen#readme",
+  "homepage": "https://github.com/theinfosecguy/servergen#readme",
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^14.0.2",
     "fs-extra": "^11.3.3"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.18",
     "vitest": "^4.0.18"
   }
 }

--- a/templates/express/index(config).js
+++ b/templates/express/index(config).js
@@ -4,6 +4,7 @@
  */
 
 const express = require('express');
+const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 const cors = require('cors');

--- a/templates/express/index.js
+++ b/templates/express/index.js
@@ -4,6 +4,7 @@
  */
 
 const express = require('express');
+const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 const cors = require('cors');

--- a/templates/express/views/ve_jade.jade
+++ b/templates/express/views/ve_jade.jade
@@ -1,7 +1,0 @@
-doctype html
-html
-    head
-        title Jade Page
-    body
-        h1 View Engine - Jade
-        p By Make-Server...

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -61,8 +61,9 @@ describe('CLI Integration', () => {
       
       expect(pkg.name).toBe('expresstest');
       expect(pkg.dependencies.express).toBeDefined();
-      expect(pkg.dependencies.nodemon).toBeDefined();
+      expect(pkg.devDependencies.nodemon).toBeDefined();
       expect(pkg.dependencies.cors).toBeDefined();
+      expect(pkg.scripts.start).toBe('node index.js');
     });
 
     it('includes view engine when specified', () => {
@@ -102,7 +103,7 @@ describe('CLI Integration', () => {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
       
       expect(pkg.dependencies.express).toBeUndefined();
-      expect(pkg.dependencies.nodemon).toBeDefined();
+      expect(pkg.devDependencies.nodemon).toBeDefined();
     });
   });
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -53,7 +53,6 @@ describe('getConfig', () => {
       const config = getConfig(baseDir, cwd);
       expect(config.validation.views).toContain('ejs');
       expect(config.validation.views).toContain('pug');
-      expect(config.validation.views).toContain('jade');
       expect(config.validation.views).toContain('hbs');
     });
   });

--- a/tests/unit/constants.test.js
+++ b/tests/unit/constants.test.js
@@ -34,12 +34,12 @@ describe('constants', () => {
       expect(VIEW_ENGINES.pug).toBeDefined();
     });
 
-    it('includes jade', () => {
-      expect(VIEW_ENGINES.jade).toBeDefined();
-    });
-
     it('includes hbs', () => {
       expect(VIEW_ENGINES.hbs).toBeDefined();
+    });
+
+    it('does not include deprecated jade', () => {
+      expect(VIEW_ENGINES.jade).toBeUndefined();
     });
   });
 
@@ -47,7 +47,6 @@ describe('constants', () => {
     it('is array of view engine names', () => {
       expect(VALID_VIEWS).toContain('ejs');
       expect(VALID_VIEWS).toContain('pug');
-      expect(VALID_VIEWS).toContain('jade');
       expect(VALID_VIEWS).toContain('hbs');
     });
 

--- a/tests/unit/validator.test.js
+++ b/tests/unit/validator.test.js
@@ -55,6 +55,47 @@ describe('validateOptions', () => {
     });
   });
 
+  describe('port validation', () => {
+    it('accepts a valid port', () => {
+      const result = validateOptions({ port: '8080' }, validationRules);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('accepts the default port', () => {
+      const result = validateOptions({ port: '3000' }, validationRules);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('rejects a port below 1', () => {
+      const result = validateOptions({ port: '0' }, validationRules);
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toContain('Invalid port');
+    });
+
+    it('rejects a negative port', () => {
+      const result = validateOptions({ port: '-5' }, validationRules);
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toContain('Invalid port');
+    });
+
+    it('rejects a port above 65535', () => {
+      const result = validateOptions({ port: '99999' }, validationRules);
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toContain('Invalid port');
+    });
+
+    it('rejects a non-numeric port', () => {
+      const result = validateOptions({ port: 'abc' }, validationRules);
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toContain('Invalid port');
+    });
+
+    it('passes when no port specified', () => {
+      const result = validateOptions({}, validationRules);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
   describe('combined validation', () => {
     it('validates both framework and view', () => {
       const result = validateOptions(

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,12 +6,17 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
+      all: true,
+      include: ['lib/**/*.js', 'bin/**/*.js', 'index.js'],
       exclude: ['tests/**', 'node_modules/**'],
+      // Thresholds reflect the true baseline now that all source files are
+      // measured (previously only 2 files were counted, inflating coverage).
+      // Raise these as coverage of the core generator modules improves.
       thresholds: {
-        statements: 70,
-        branches: 60,
-        functions: 70,
-        lines: 70,
+        statements: 12,
+        branches: 15,
+        functions: 10,
+        lines: 12,
       },
     },
   },


### PR DESCRIPTION
# Problem & Solution Overview

A review of the generator surfaced defects that ship into every scaffolded project, plus packaging, DX, and dependency-staleness gaps. This PR batches the low-risk, high-value fixes and a dependency refresh:

- **Express apps with a view engine crashed on boot** (`ReferenceError: path is not defined`) because the injected `app.set('views', path.join(...))` ran in a template that never required `path`. The express templates now require `path`.
- **`npm install` ran via a shell string** (`exec(\`cd ${dir} && npm install\`)`) with an unquoted, partially-untrusted path. Replaced with `spawn('npm', ['install'], { cwd, shell: false })`, removing the command-injection surface and the spaces-break-install bug.
- **Weak input handling:** an app name that sanitized to empty targeted the current directory, and ports like `0`, `-5`, and `99999` were accepted. The CLI now rejects empty names and ports outside `1..65535`.
- **Deprecated `jade`** view engine removed (pug already covers it), dropping a dead, vulnerable dependency tree from generated apps.
- **`nodemon` moved to `devDependencies`** in generated apps, with `start` set to `node index.js` and a `dev` script for nodemon, so the prod start command and Dockerfile `CMD` agree.
- **Package was not importable:** `main` pointed at the self-executing CLI bin, so `import 'servergen'` triggered argv parsing. `main` now points at the library entry `index.js`.
- **Misleading coverage:** only 2 of 11 source files were measured (~85% reported). Coverage now includes all source files (true ~13% baseline) with recalibrated thresholds that actually guard against regressions.
- **Packaging/docs:** added a `files` allowlist so tests and CI configs are no longer published to npm; documented the existing `--port`, `--skip-install`, and `--debug` flags; and fixed stale metadata (CONTRIBUTING heading, blank Code of Conduct contact).
- **Dependency refresh:** generated apps now scaffold onto current majors — express `4 → 5`, mongoose `8 → 9`, ejs `3 → 6` — plus minor bumps for cors, pug, hbs, and nodemon. servergen's own dependency floors were refreshed to their latest within the current major (commander stays on 14 so Node 18 remains supported).

The larger `--db`-overwrites-`--port`/`--view` correctness issue and security hardening of generated defaults are tracked separately.

# Testing Done

- `npm test`: 64 passing (added 7 port-validation cases; updated jade/nodemon assertions). Green on the Node 18 / 20 / 22 CI matrix.
- `npm run test:coverage`: measures all source files and passes the recalibrated thresholds.
- End-to-end flow with the bumped majors: generated an `express + ejs + --port 5099` app, installed its deps (express 5.2.1, ejs 6.0.1, cors 2.8.6), booted it, and made a real request — `GET / -> 200 {"message":"Welcome to ServerGen!"}`, confirming express 5 routing works.
- `--db` variant: generated and installed cleanly with express 5 + mongoose 9 + ejs 6 together (no peer conflicts); index.js passes `node --check`. Not booted because it needs a live MongoDB.
- Verified the new guards reject empty/invalid names, ports `0`/`99999`, and `jade`, while valid node/express generation still succeeds.
- `import('./index.js')` returns the library exports without triggering the CLI.
- `npm pack --dry-run` confirms only `bin/`, `lib/`, `index.js`, `templates/`, `README.md`, and `LICENSE` are published.
