### PR TITLE
Stop --db from discarding --port and --view; reject node view engines

### DIFF
--- a/lib/app_generator.js
+++ b/lib/app_generator.js
@@ -129,9 +129,13 @@ class AppGenerator {
   }
 
   /**
-   * Sets up view engine if specified.
+   * Sets up view engine if specified. View engines are express-only, so this
+   * is a no-op for the node framework.
    */
   setupViews() {
+    if (this.framework === 'node') {
+      return;
+    }
     this.fileCreator.handleViews(
       this.folderDir,
       this.config.paths.templates.views,

--- a/lib/file_generator.js
+++ b/lib/file_generator.js
@@ -84,7 +84,10 @@ const generatePackage = (folderDir, appName, view, config, framework) => {
  * @param {boolean} config - Whether to include mongoose configuration.
  */
 const createExpressApp = (templatesDir, folderDir, appName, view, config) => {
-  const basePath = path.join(templatesDir, 'index.js');
+  // Select the correct base index.js up front (config variant vs plain) so that
+  // later port and view edits operate on the final file and are not overwritten.
+  const indexTemplate = config ? 'index(config).js' : 'index.js';
+  const basePath = path.join(templatesDir, indexTemplate);
   fs_helper.buildFilewithContents(basePath, folderDir, 'index.js');
   generateMVC(folderDir, templatesDir);
   generatePackage(folderDir, appName, view, config, 'express');
@@ -161,6 +164,9 @@ const manageViews = (folderPath, viewName, addView) => {
 
 /**
  * Sets up MongoDB/Mongoose configuration files.
+ * The config-aware index.js is chosen in createExpressApp, so this only writes
+ * the mongoose config and must not overwrite index.js (which would discard any
+ * port and view edits already applied).
  * @param {string} folderDir - The application directory path.
  * @param {string} templatesDir - Path to templates directory.
  */
@@ -173,8 +179,6 @@ const handleConfig = (folderDir, templatesDir) => {
     path.join(folderDir, 'config'),
     'mongoose.js'
   );
-  const newIndexPath = path.join(templatesDir, 'index(config).js');
-  fs_helper.buildFilewithContents(newIndexPath, folderDir, 'index.js');
 };
 
 /**

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -24,6 +24,10 @@ export const validateOptions = (options, validationRules) => {
     errors.push(`Invalid view engine: ${options.view}. Valid options: ${validationRules.views.join(', ')}`);
   }
 
+  if (options.framework === 'node' && options.view) {
+    errors.push('View engines are only supported with the express framework. Use --framework express or remove --view.');
+  }
+
   if (options.port !== undefined && options.port !== null) {
     const portNum = Number(options.port);
     if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -127,11 +127,60 @@ describe('CLI Integration', () => {
   describe('custom port', () => {
     it('configures custom port in index.js', () => {
       runCLI('-n porttest -f express -p 8080 --skip-install');
-      
+
       const indexPath = path.join(testOutput, 'porttest', 'index.js');
       const content = fs.readFileSync(indexPath, 'utf-8');
-      
+
       expect(content).toContain('8080');
+    });
+  });
+
+  describe('database combined with port and views', () => {
+    it('keeps the custom port when --db is used', () => {
+      runCLI('-n dbport -f express --db -p 8080 --skip-install');
+
+      const content = fs.readFileSync(
+        path.join(testOutput, 'dbport', 'index.js'),
+        'utf-8'
+      );
+      expect(content).toContain('8080');
+      expect(content).toContain("require('./config/mongoose')");
+    });
+
+    it('keeps the view engine when --db is used', () => {
+      runCLI('-n dbview -f express --db -v ejs --skip-install');
+
+      const content = fs.readFileSync(
+        path.join(testOutput, 'dbview', 'index.js'),
+        'utf-8'
+      );
+      expect(content).toContain('view engine');
+      expect(content).toContain('ejs');
+      expect(content).toContain("require('./config/mongoose')");
+    });
+
+    it('keeps both port and view when --db, --port and --view are combined', () => {
+      runCLI('-n dball -f express --db -v ejs -p 8080 --skip-install');
+
+      const content = fs.readFileSync(
+        path.join(testOutput, 'dball', 'index.js'),
+        'utf-8'
+      );
+      expect(content).toContain('8080');
+      expect(content).toContain('ejs');
+      expect(content).toContain("require('./config/mongoose')");
+    });
+  });
+
+  describe('unsupported flag combinations', () => {
+    it('rejects --view with the node framework', () => {
+      expect(() => runCLI('-n nodeview -f node -v ejs --skip-install')).toThrow();
+      expect(fs.existsSync(path.join(testOutput, 'nodeview'))).toBe(false);
+    });
+
+    it('does not create a views directory for node apps', () => {
+      runCLI('-n nodenoview -f node --skip-install');
+      expect(fs.existsSync(path.join(testOutput, 'nodenoview', 'views'))).toBe(false);
     });
   });
 });

--- a/tests/unit/validator.test.js
+++ b/tests/unit/validator.test.js
@@ -96,6 +96,30 @@ describe('validateOptions', () => {
     });
   });
 
+  describe('framework and view compatibility', () => {
+    it('rejects a view engine with the node framework', () => {
+      const result = validateOptions(
+        { framework: 'node', view: 'ejs' },
+        validationRules
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some((e) => e.includes('express framework'))).toBe(true);
+    });
+
+    it('allows a view engine with the express framework', () => {
+      const result = validateOptions(
+        { framework: 'express', view: 'ejs' },
+        validationRules
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('allows the node framework without a view engine', () => {
+      const result = validateOptions({ framework: 'node' }, validationRules);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
   describe('combined validation', () => {
     it('validates both framework and view', () => {
       const result = validateOptions(


### PR DESCRIPTION
# Problem & Solution Overview

Combining `--db` with `--port` and/or `--view` silently discarded both. Generation wrote `index.js`, applied the port and view edits, then the database step overwrote `index.js` wholesale with the pristine config template, dropping those edits (while still printing "Port configured to ...").

The db-aware `index.js` is now selected up front in `createExpressApp`, and `handleConfig` only writes the mongoose config rather than re-copying `index.js`. Port and view edits therefore apply to the final file and survive.

Separately, `--view` with `--framework node` produced a dead `views/` folder and an unused view dependency, because the node template is a bare http server with no express app to wire a view engine into. The CLI now rejects `--view` with the node framework, and node apps no longer get a `views/` directory.

# Testing Done

- `npm test`: 72 passing. Added integration cases for `--db` combined with `--port`, `--view`, and both, asserting `index.js` keeps all of them plus the `require('./config/mongoose')`; added node+view rejection cases and validator unit tests.
- Generated `express --db -v ejs -p 8080`: `index.js` keeps port `8080`, the ejs view wiring (`app.set('view engine','ejs')` + `path.join`), and the mongoose require; `config/mongoose.js` is created.
- `node --check` passes for plain / db-only / db+port / node variants; db-only has no leftover `// Views` marker; the plain app has no mongoose require; node apps have no `views/` dir.
- `servergen -n x -f node -v ejs` exits non-zero with a clear message and creates nothing.
