### PR TITLE
Decouple the library from process exit and add a createGenerator factory

### DIFF
--- a/bin/servergen.js
+++ b/bin/servergen.js
@@ -10,11 +10,8 @@ import path from 'path';
 import { createRequire } from 'module';
 import { program } from 'commander';
 import { getConfig } from '../lib/config.js';
-import { validateOptions, handleValidationErrors } from '../lib/validator.js';
-import AppGenerator from '../lib/app_generator.js';
-import * as fsHelper from '../lib/build_helper.js';
-import * as fileCreator from '../lib/file_generator.js';
-import * as displayer from '../lib/log_display.js';
+import { validateOptions } from '../lib/validator.js';
+import { createGenerator } from '../index.js';
 import * as fileName from '../lib/fileName.js';
 import * as logger from '../lib/logger.js';
 
@@ -45,7 +42,10 @@ if (options.debug) {
 logger.debug('CLI options received', options);
 
 const validationResult = validateOptions(options, config.validation);
-handleValidationErrors(validationResult);
+if (!validationResult.isValid) {
+  validationResult.errors.forEach((error) => logger.error(error));
+  process.exit(1);
+}
 
 const appName = fileName.cleanAppName(options.name);
 
@@ -65,28 +65,20 @@ logger.debug('Parsed configuration', { appName, port, framework: options.framewo
  * Main function to run the application generator.
  */
 const main = async () => {
-  const generator = new AppGenerator(
-    {
-      appName,
-      framework: options.framework,
-      view: options.view,
-      db: options.db,
-      port,
-      skipInstall,
-      config,
-    },
-    {
-      fsHelper,
-      fileCreator,
-      displayer,
-      logger,
-    }
-  );
+  const generator = createGenerator({
+    appName,
+    framework: options.framework,
+    view: options.view,
+    db: options.db,
+    port,
+    skipInstall,
+    config,
+  });
 
   try {
     await generator.generate();
   } catch (err) {
-    logger.error('Generation failed', err);
+    logger.error(err.message, err);
     process.exit(1);
   }
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 import AppGenerator from './lib/app_generator.js';
 import { getConfig } from './lib/config.js';
-import { validateOptions, handleValidationErrors } from './lib/validator.js';
+import { validateOptions } from './lib/validator.js';
 import * as fsHelper from './lib/build_helper.js';
 import * as fileCreator from './lib/file_generator.js';
 import * as displayer from './lib/log_display.js';
@@ -13,11 +13,22 @@ import * as fileName from './lib/fileName.js';
 import { handleError, withErrorHandling } from './lib/error_handler.js';
 import * as logger from './lib/logger.js';
 
+/**
+ * Creates an AppGenerator wired with the default library dependencies.
+ * Acts as the composition root so callers (the CLI or programmatic users)
+ * do not have to assemble the dependency bundle themselves.
+ * @param {Object} options - Generation options (see AppGenerator constructor).
+ * @returns {AppGenerator} A ready-to-use generator instance.
+ */
+const createGenerator = (options) => {
+  return new AppGenerator(options, { fsHelper, fileCreator, displayer, logger });
+};
+
 export {
   AppGenerator,
+  createGenerator,
   getConfig,
   validateOptions,
-  handleValidationErrors,
   fsHelper,
   fileCreator,
   displayer,

--- a/lib/app_generator.js
+++ b/lib/app_generator.js
@@ -6,8 +6,6 @@
 import path from 'path';
 import { spawn } from 'child_process';
 import fs from 'fs-extra';
-import chalk from 'chalk';
-import { handleError } from './error_handler.js';
 
 /**
  * AppGenerator class that handles the complete app generation workflow.
@@ -167,14 +165,14 @@ class AppGenerator {
    */
   async installDependencies() {
     this.displayer.beginMessage(this.appName);
-    console.log('Installing required NPM Packages. This might take a while.');
+    this.logger?.info('Installing required NPM Packages. This might take a while.');
 
     try {
       await this.runNpmInstall();
-      console.log(chalk.green('\nNPM Packages Installed Successfully'));
+      this.logger?.success('NPM Packages installed successfully');
       this.displayer.endMessage(this.appName);
     } catch (err) {
-      handleError(err, 'Failed to install dependencies');
+      this.logger?.error('Failed to install dependencies', err);
       throw err;
     }
   }

--- a/lib/build_helper.js
+++ b/lib/build_helper.js
@@ -5,7 +5,6 @@
 
 import path from 'path';
 import fs from 'fs-extra';
-import chalk from 'chalk';
 
 /**
  * Creates a directory inside the specified app directory.
@@ -29,20 +28,20 @@ export const buildFilewithContents = (readFrom, folderDir, fileName) => {
 };
 
 /**
- * Creates the main application folder. Exits if folder already exists.
+ * Creates the main application folder.
  * @param {string} folderDir - The path of the folder to create.
+ * @throws {Error} If the folder already exists or cannot be created. Callers
+ *   (e.g. the CLI) decide how to report the failure and whether to exit.
  */
 export const buildFolderforApp = (folderDir) => {
   try {
     fs.mkdirSync(folderDir);
   } catch (err) {
     if (err.code === 'EEXIST') {
-      console.error(
-        chalk.red(`Directory ${folderDir} already exists, Please Try Again`)
+      throw new Error(
+        `Directory ${folderDir} already exists. Choose a different app name or remove the existing directory.`
       );
-      process.exit(1);
-    } else {
-      throw err;
     }
+    throw err;
   }
 };

--- a/lib/file_generator.js
+++ b/lib/file_generator.js
@@ -146,17 +146,15 @@ const manageViews = (folderPath, viewName, addView) => {
   const viewString = `app.set('view engine','${viewName}') \n app.set('views', path.join(__dirname, 'views'));`;
   const jsFile = path.join(folderPath, 'index.js');
 
-  try {
-    let data = fs.readFileSync(jsFile, 'utf8');
-    if (addView) {
-      data = data.replace('// Views', viewString);
-    } else {
-      data = data.replace('// Views', '');
-    }
-    fs.writeFileSync(jsFile, data, 'utf8');
-  } catch (err) {
-    console.log(err);
+  // Let read/write failures propagate so a corrupt index.js is not reported
+  // as a successful generation.
+  let data = fs.readFileSync(jsFile, 'utf8');
+  if (addView) {
+    data = data.replace('// Views', viewString);
+  } else {
+    data = data.replace('// Views', '');
   }
+  fs.writeFileSync(jsFile, data, 'utf8');
 };
 
 /**

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -3,8 +3,6 @@
  * @module lib/validator
  */
 
-import chalk from 'chalk';
-
 /**
  * Validates CLI options against allowed values.
  * @param {Object} options - CLI options object.
@@ -35,17 +33,4 @@ export const validateOptions = (options, validationRules) => {
     isValid: errors.length === 0,
     errors,
   };
-};
-
-/**
- * Prints validation errors and exits if invalid.
- * @param {Object} validationResult - Result from validateOptions.
- */
-export const handleValidationErrors = (validationResult) => {
-  if (!validationResult.isValid) {
-    validationResult.errors.forEach((error) => {
-      console.error(chalk.red(error));
-    });
-    process.exit(1);
-  }
 };

--- a/tests/unit/build_helper.test.js
+++ b/tests/unit/build_helper.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -50,19 +50,13 @@ describe('build_helper', () => {
       expect(fs.existsSync(newFolder)).toBe(true);
     });
 
-    it('exits if folder already exists', () => {
+    it('throws if folder already exists', () => {
       const existingFolder = path.join(testDir, 'existing');
       fs.mkdirSync(existingFolder);
 
-      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
-        throw new Error('process.exit called');
-      });
-
       expect(() => {
         buildHelper.buildFolderforApp(existingFolder);
-      }).toThrow('process.exit called');
-
-      mockExit.mockRestore();
+      }).toThrow(/already exists/);
     });
   });
 });


### PR DESCRIPTION
# Problem & Solution Overview

The library mixed process-level side effects into reusable modules: `buildFolderforApp` and `handleValidationErrors` called `process.exit`, `manageViews` swallowed write errors with `console.log(err)`, and `installDependencies` bypassed the injected logger with raw `console.log`/`chalk` and a direct `handleError` import. The CLI also re-assembled the dependency bundle by hand, duplicating wiring that belongs with the library.

This decouples those concerns so the library is embeddable and testable:

- `buildFolderforApp` throws a clear error instead of calling `process.exit`; the CLI catches it, prints the message, and exits.
- Validation no longer exits from the library. `handleValidationErrors` (a CLI-only `process.exit` wrapper) is removed; the CLI inspects `validateOptions`' result and exits.
- `manageViews` lets read/write failures propagate instead of swallowing them, so a corrupt `index.js` is no longer reported as a successful generation.
- `installDependencies` routes output through the injected logger rather than raw `console.log`/`chalk`/`handleError`.
- A `createGenerator()` composition root in `index.js` wires the default dependencies, so `bin` only parses argv and delegates.

Note: this is a small public-API change — `handleValidationErrors` is removed and `createGenerator` is added. Generated-app output and CLI behavior are unchanged.

# Testing Done

- `npm test`: 64 passing. The `build_helper` test now asserts a thrown error rather than a mocked `process.exit`.
- Generated `express -v ejs -p 6001`: succeeds and the generated `index.js` passes `node --check`.
- A duplicate target directory now prints `Directory ... already exists. Choose a different app name ...` and exits 1 (previously a low-level `process.exit` inside the FS helper).
- Invalid options still exit 1 with the validation message.
- `import('./index.js')` exposes `createGenerator` (function) and no longer exposes `handleValidationErrors`.

Independent of #27 (both branch from `main`, touching different regions of a few shared files); whichever merges second may need a trivial rebase.
