### PR TITLE
Switch coverage to the istanbul provider so source files are instrumented

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "^11.3.5"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.8",
+    "@vitest/coverage-istanbul": "^4.1.8",
     "vitest": "^4.1.8"
   }
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,19 +4,15 @@ export default defineConfig({
   test: {
     include: ['tests/unit/**/*.test.js', 'tests/integration/**/*.test.js'],
     coverage: {
-      provider: 'v8',
+      provider: 'istanbul',
       reporter: ['text', 'html'],
-      all: true,
       include: ['lib/**/*.js', 'bin/**/*.js', 'index.js'],
       exclude: ['tests/**', 'node_modules/**'],
-      // Thresholds reflect the true baseline now that all source files are
-      // measured (previously only 2 files were counted, inflating coverage).
-      // Raise these as coverage of the core generator modules improves.
       thresholds: {
-        statements: 12,
-        branches: 15,
-        functions: 10,
-        lines: 12,
+        statements: 80,
+        branches: 80,
+        functions: 85,
+        lines: 80,
       },
     },
   },


### PR DESCRIPTION
# Problem & Solution Overview

`npm run test:coverage` instrumented 0 source files in this environment (reported `0/0`, "Unknown%") because the v8 provider produced no coverage data, so the thresholds were meaningless and coverage of the recently-added unit tests was invisible.

Switching the provider to istanbul (Babel-based instrumentation, independent of Node's V8 inspector) fixes it. Coverage now reports real per-file numbers: with the current tests the suite covers ~86% of statements, ~85% branches, ~94% functions, and ~87% lines. Thresholds are set just below that baseline (80 / 80 / 85 / 80) so the gate is meaningful and guards against regressions. The deprecated `all: true` option (removed in Vitest v3+) was dropped, since istanbul includes all `include`d files by default.

# Testing Done

- `npm run test:coverage`: exits 0 and reports `All files 86.36 | 85.29 | 93.61 | 86.72` (previously `0 | 0 | 0 | 0`).
- `npm test`: 201 passing, unchanged.
