### PR TITLE
Give each test its own temporary directory

### DIFF
--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -1,16 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.join(__dirname, '..', '..');
-const testOutput = path.join(__dirname, '.integration-output');
+let testOutput;
 
 describe('CLI Integration', () => {
   beforeEach(() => {
-    fs.ensureDirSync(testOutput);
+    testOutput = fs.mkdtempSync(path.join(os.tmpdir(), 'servergen-integration-'));
   });
 
   afterEach(() => {

--- a/tests/unit/app_generator.test.js
+++ b/tests/unit/app_generator.test.js
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import AppGenerator from '../../lib/app_generator.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const testDir = path.join(__dirname, '.test-output-app-generator');
+let testDir;
 
 /**
  * Build a fresh set of mocked dependencies for each test.
@@ -56,7 +55,7 @@ describe('AppGenerator', () => {
   let config;
 
   beforeEach(() => {
-    fs.ensureDirSync(testDir);
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'servergen-app-generator-'));
     deps = makeDeps();
     config = makeConfig();
   });

--- a/tests/unit/build_helper.test.js
+++ b/tests/unit/build_helper.test.js
@@ -1,15 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import * as buildHelper from '../../lib/build_helper.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const testDir = path.join(__dirname, '.test-output');
+let testDir;
 
 describe('build_helper', () => {
   beforeEach(() => {
-    fs.ensureDirSync(testDir);
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'servergen-build-helper-'));
   });
 
   afterEach(() => {

--- a/tests/unit/file_generator.test.js
+++ b/tests/unit/file_generator.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import {
@@ -17,7 +18,7 @@ import { VIEW_ENGINES, DEPENDENCY_VERSIONS } from '../../lib/constants.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const templatesDir = path.join(__dirname, '..', '..', 'templates', 'express');
 const viewsDir = path.join(templatesDir, 'views');
-const testDir = path.join(__dirname, '.test-output-file-generator');
+let testDir;
 
 const readPkg = (folderDir) =>
   JSON.parse(fs.readFileSync(path.join(folderDir, 'package.json'), 'utf-8'));
@@ -29,7 +30,7 @@ describe('file_generator', () => {
   let logSpy;
 
   beforeEach(() => {
-    fs.ensureDirSync(testDir);
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'servergen-file-generator-'));
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 


### PR DESCRIPTION
# Problem & Solution Overview

The unit and integration tests shared fixed output directories under the repo (`.test-output`, `.test-output-*`, `.integration-output`), so two concurrent runs (e.g. `npm test` alongside `npm run test:coverage`) could delete each other's files mid-test. Each test now creates a unique directory under the OS temp dir in `beforeEach` (`fs.mkdtempSync`) and removes only its own directory in `afterEach`.

# Testing Done

`npm test`: 203 passing. `npm test` and `npm run test:coverage` run concurrently with both passing (exit 0, 203 each). No shared output directories remain under the repo.
