### PR TITLE
Publish to npm via OIDC in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
 
-# Release gate: run the heavy package smoke test BEFORE any release. It packs,
-# installs the tarball, scaffolds Node and Express apps, boots their servers and
-# verifies a live HTTP response. This is intentionally kept out of the per-PR
-# ci.yml job. No registry publish credentials are configured here; the workflow
-# only proves the published package works end to end.
+# Release pipeline:
+# 1) smoke: pack, install the tarball, scaffold Node and Express apps, boot their
+#    servers and verify a live HTTP response. Kept out of the per-PR ci.yml job.
+# 2) publish: on a version tag, publish to npm using OIDC trusted publishing
+#    (no long-lived token; provenance is attached automatically).
 on:
   push:
     tags:
@@ -28,3 +28,28 @@ jobs:
 
       - name: Run package smoke test
         run: npm run test:package
+
+  publish:
+    needs: smoke
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Publish to npm
+        run: npm publish


### PR DESCRIPTION
# Problem & Solution Overview

The release workflow ran the package smoke test but had no publish step. It now adds a `publish` job that runs after the smoke test and, on a version tag (`refs/tags/v*`), publishes to npm using OIDC trusted publishing — no long-lived token, provenance attached automatically. It upgrades npm to a trusted-publishing-capable version (>= 11.5.1) and sets `id-token: write`.

# Testing Done

`release.yml` validated as YAML. Publish is gated to version tags and depends on the smoke job, so pushing `v1.3.0` runs smoke → publish.
