### PR TITLE
Fix the npm release: explicit latest tag and bin path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,5 +51,7 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@latest
 
+      # Explicit --tag latest: an old 2.0.0 exists on the registry, so npm will
+      # not implicitly move the latest tag onto the lower (but newer) 1.3.0.
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --tag latest

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "author": "Keshav Malik",
   "bin": {
-    "servergen": "./bin/servergen.js"
+    "servergen": "bin/servergen.js"
   },
   "preferGlobal": true,
   "license": "MIT",


### PR DESCRIPTION
# Problem & Solution Overview

The `v1.3.0` release published via OIDC (auth worked) but `npm publish` was rejected: an old `2.0.0` exists on the registry, so npm would not implicitly move the `latest` tag onto the lower-but-newer `1.3.0`. The publish step now passes `--tag latest` explicitly. Also normalizes the `bin` path (`./bin/servergen.js` → `bin/servergen.js`) to match the form npm stores and silence a publish warning.

# Testing Done

`release.yml` validated; `bin` matches the published `1.2.0` form. Re-tagging `v1.3.0` after merge re-runs smoke → publish.
