### PR TITLE
Use OIDC trusted publishing (drop registry-url)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No registry-url here: setup-node's registry-url writes a dummy auth token
+      # into .npmrc, which shadows OIDC and makes npm attempt (failing) token
+      # auth. Without it, npm finds no token and uses OIDC trusted publishing.
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1.
       - name: Upgrade npm


### PR DESCRIPTION
# Problem & Solution Overview

The `v1.3.0` publish returned E404 ("you do not have permission"): `setup-node`'s `registry-url` writes a dummy `NODE_AUTH_TOKEN` into `.npmrc`, so npm attempted (failing) token auth instead of OIDC. Removing `registry-url` leaves no token configured, so npm uses OIDC trusted publishing (it defaults to the npmjs.org registry).

# Testing Done

`release.yml` validated. Re-tagging `v1.3.0` after merge re-runs smoke → publish via OIDC.
