### PR TITLE
Diagnose OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,17 +41,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # No registry-url here: setup-node's registry-url writes a dummy auth token
-      # into .npmrc, which shadows OIDC and makes npm attempt (failing) token
-      # auth. Without it, npm finds no token and uses OIDC trusted publishing.
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1.
       - name: Upgrade npm
         run: npm install -g npm@latest
+
+      - name: Diagnostics
+        run: |
+          node --version
+          npm --version
+          echo "id-token request URL present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+YES}"
+          npm config get registry
 
       # Explicit --tag latest: an old 2.0.0 exists on the registry, so npm will
       # not implicitly move the latest tag onto the lower (but newer) 1.3.0.


### PR DESCRIPTION
Adds a diagnostics step (npm version, OIDC token presence) and restores registry-url to debug the failing publish.