### PR TITLE
Remove the publish diagnostics step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,6 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@latest
 
-      - name: Diagnostics
-        run: |
-          node --version
-          npm --version
-          echo "id-token request URL present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+YES}"
-          npm config get registry
-
       # Explicit --tag latest: an old 2.0.0 exists on the registry, so npm will
       # not implicitly move the latest tag onto the lower (but newer) 1.3.0.
       - name: Publish to npm


### PR DESCRIPTION
Drops the temporary diagnostics step now that OIDC trusted publishing works.