### PR TITLE
Make generated Express apps production-ready

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -40,4 +40,6 @@ export const DEPENDENCY_VERSIONS = {
   cors: '^2.8.6',
   express: '^5.2.1',
   mongoose: '^9.7.0',
+  dotenv: '^17.4.2',
+  supertest: '^7.2.2',
 };

--- a/lib/file_generator.js
+++ b/lib/file_generator.js
@@ -59,6 +59,9 @@ const generatePackage = (folderDir, appName, view, config, framework) => {
 
   if (framework === 'express') {
     pkg.dependencies.express = DEPENDENCY_VERSIONS.express;
+    pkg.dependencies.dotenv = DEPENDENCY_VERSIONS.dotenv;
+    pkg.scripts.test = 'node --test';
+    pkg.devDependencies.supertest = DEPENDENCY_VERSIONS.supertest;
   }
 
   if (view && VIEW_ENGINES[view]) {
@@ -91,7 +94,25 @@ const createExpressApp = (templatesDir, folderDir, appName, view, config) => {
   fs_helper.buildFilewithContents(basePath, folderDir, 'index.js');
   generateMVC(folderDir, templatesDir);
   generatePackage(folderDir, appName, view, config, 'express');
+  generateAppTest(folderDir, templatesDir);
   console.log('Generating Express application..');
+};
+
+/**
+ * Copies the generated app's integration test into a test/ directory.
+ * @param {string} folderDir - The application directory path.
+ * @param {string} templatesDir - Path to Express templates.
+ */
+const generateAppTest = (folderDir, templatesDir) => {
+  const testTemplate = path.join(templatesDir, 'test', 'app.test.js');
+  if (fs.existsSync(testTemplate)) {
+    fs_helper.createDir(folderDir, 'test');
+    fs_helper.buildFilewithContents(
+      testTemplate,
+      path.join(folderDir, 'test'),
+      'app.test.js'
+    );
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "servergen",
   "version": "1.4.0",
-  "description": "Tool to create Node/Express Environment setup within minutes.",
+  "description": "CLI that scaffolds production-ready Node.js and Express apps with MVC structure, optional view engines, MongoDB, and Docker support.",
   "type": "module",
   "main": "./index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servergen",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Tool to create Node/Express Environment setup within minutes.",
   "type": "module",
   "main": "./index.js",

--- a/templates/express/config/mongoose.js
+++ b/templates/express/config/mongoose.js
@@ -1,20 +1,22 @@
 /**
  * MongoDB connection configuration using Mongoose.
- * @description Establishes connection to MongoDB database.
+ * @description Connects to MongoDB using the MONGODB_URI environment variable
+ * (falling back to a local database), and exports the mongoose instance.
  */
+
+require('dotenv').config();
 
 const mongoose = require('mongoose');
 
-mongoose.connect('mongodb://localhost/demo_db');
+const uri = process.env.MONGODB_URI || 'mongodb://localhost/demo_db';
 
-// Acquire the connection - To access DB
-const db = mongoose.connection;
+mongoose
+  .connect(uri)
+  .then(function () {
+    console.log('Connected to MongoDB');
+  })
+  .catch(function (err) {
+    console.error('MongoDB connection error:', err.message);
+  });
 
-// To have a check on Error
-db.on('error', console.error.bind(console, 'connection error:'));
-
-// Once Connection is Open
-db.once('open', function () {
-  // we're connected!
-  console.log('Connected to DB');
-});
+module.exports = mongoose;

--- a/templates/express/index(config).js
+++ b/templates/express/index(config).js
@@ -1,14 +1,19 @@
 /**
  * Express application entry point with MongoDB configuration.
- * @description Main server configuration with CORS, routing, and database setup.
+ * @description Production-ready server with MongoDB, a health check, centralized
+ * error handling, and graceful shutdown. The app is exported so it can be
+ * imported by tests; it only starts listening when run directly.
  */
+
+require('dotenv').config();
 
 const express = require('express');
 const path = require('path');
+const cors = require('cors');
+const mongoose = require('./config/mongoose');
+
 const app = express();
 const port = process.env.PORT || 3000;
-const cors = require('cors');
-require('./config/mongoose');
 
 // Views
 
@@ -16,14 +21,47 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// Using express router
+// Health check endpoint.
+app.get('/health', function (req, res) {
+  res.status(200).json({ status: 'ok' });
+});
+
 app.use('/', require('./routes'));
 
-// Listening on Port
-app.listen(port, function (err) {
-  if (err) {
-    console.log('Error in running Express Server ');
-    return;
-  }
-  console.log('Express Server started on port ', port);
+// Centralized error-handling middleware (must be registered last).
+// eslint-disable-next-line no-unused-vars
+app.use(function (err, req, res, next) {
+  console.error(err.stack);
+  res
+    .status(err.status || 500)
+    .json({ error: err.message || 'Internal Server Error' });
 });
+
+if (require.main === module) {
+  // Bind to 0.0.0.0 so the server is reachable from outside a container.
+  const server = app.listen(port, '0.0.0.0', function () {
+    console.log('Express server started on port ' + port);
+  });
+
+  const shutdown = function (signal) {
+    console.log(signal + ' received, shutting down gracefully');
+    server.close(async function () {
+      try {
+        await mongoose.connection.close();
+      } catch (err) {
+        // ignore close errors during shutdown
+      }
+      console.log('Server closed');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGINT', function () {
+    shutdown('SIGINT');
+  });
+  process.on('SIGTERM', function () {
+    shutdown('SIGTERM');
+  });
+}
+
+module.exports = app;

--- a/templates/express/index.js
+++ b/templates/express/index.js
@@ -1,13 +1,18 @@
 /**
  * Express application entry point.
- * @description Main server configuration with CORS and routing setup.
+ * @description Production-ready server with a health check, centralized error
+ * handling, and graceful shutdown. The app is exported so it can be imported by
+ * tests; it only starts listening when run directly.
  */
+
+require('dotenv').config();
 
 const express = require('express');
 const path = require('path');
+const cors = require('cors');
+
 const app = express();
 const port = process.env.PORT || 3000;
-const cors = require('cors');
 
 // Views
 
@@ -15,13 +20,42 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// Health check endpoint.
+app.get('/health', function (req, res) {
+  res.status(200).json({ status: 'ok' });
+});
+
 app.use('/', require('./routes'));
 
-// Listening on Port
-app.listen(port, function (err) {
-  if (err) {
-    console.log('Error in running Express Server ');
-    return;
-  }
-  console.log('Express Server started on port ', port);
+// Centralized error-handling middleware (must be registered last).
+// eslint-disable-next-line no-unused-vars
+app.use(function (err, req, res, next) {
+  console.error(err.stack);
+  res
+    .status(err.status || 500)
+    .json({ error: err.message || 'Internal Server Error' });
 });
+
+if (require.main === module) {
+  // Bind to 0.0.0.0 so the server is reachable from outside a container.
+  const server = app.listen(port, '0.0.0.0', function () {
+    console.log('Express server started on port ' + port);
+  });
+
+  const shutdown = function (signal) {
+    console.log(signal + ' received, shutting down gracefully');
+    server.close(function () {
+      console.log('Server closed');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGINT', function () {
+    shutdown('SIGINT');
+  });
+  process.on('SIGTERM', function () {
+    shutdown('SIGTERM');
+  });
+}
+
+module.exports = app;

--- a/templates/express/test/app.test.js
+++ b/templates/express/test/app.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const app = require('../index');
+
+test('GET /health returns 200 with an ok status', async () => {
+  const res = await request(app).get('/health');
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.body.status, 'ok');
+});
+
+test('GET / returns 200', async () => {
+  const res = await request(app).get('/');
+  assert.strictEqual(res.statusCode, 200);
+});

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -319,4 +319,94 @@ describe('CLI Integration', () => {
       expectCLIError('zeroport -p 0 --skip-install', 'Invalid port');
     });
   });
+
+  describe('production-ready Express app', () => {
+    const generateExpress = (name, extra = '') => {
+      runCLI(`${name} -f express ${extra} --skip-install`.replace(/\s+/g, ' ').trim());
+      return path.join(testOutput, name);
+    };
+
+    it('includes a /health endpoint', () => {
+      const index = fs.readFileSync(
+        path.join(generateExpress('healthapp'), 'index.js'),
+        'utf-8'
+      );
+      expect(index).toContain("app.get('/health'");
+      expect(index).toContain("status: 'ok'");
+    });
+
+    it('loads dotenv and exports the app for testing', () => {
+      const index = fs.readFileSync(
+        path.join(generateExpress('dotenvapp'), 'index.js'),
+        'utf-8'
+      );
+      expect(index).toContain("require('dotenv').config()");
+      expect(index).toContain('module.exports = app');
+      expect(index).toContain('require.main === module');
+    });
+
+    it('binds to 0.0.0.0 and handles SIGINT/SIGTERM', () => {
+      const index = fs.readFileSync(
+        path.join(generateExpress('shutapp'), 'index.js'),
+        'utf-8'
+      );
+      expect(index).toContain("'0.0.0.0'");
+      expect(index).toContain("process.on('SIGINT'");
+      expect(index).toContain("process.on('SIGTERM'");
+      expect(index).toContain('server.close');
+    });
+
+    it('registers centralized error-handling middleware', () => {
+      const index = fs.readFileSync(
+        path.join(generateExpress('errapp'), 'index.js'),
+        'utf-8'
+      );
+      expect(index).toContain('Internal Server Error');
+    });
+
+    it('adds dotenv, start/dev/test scripts and supertest', () => {
+      const pkg = JSON.parse(
+        fs.readFileSync(
+          path.join(generateExpress('scriptsapp'), 'package.json'),
+          'utf-8'
+        )
+      );
+      expect(pkg.dependencies.dotenv).toBeDefined();
+      expect(pkg.scripts.start).toBe('node index.js');
+      expect(pkg.scripts.dev).toBe('nodemon index.js');
+      expect(pkg.scripts.test).toBe('node --test');
+      expect(pkg.devDependencies.supertest).toBeDefined();
+    });
+
+    it('generates a basic integration test', () => {
+      const testFile = path.join(
+        generateExpress('testedapp'),
+        'test',
+        'app.test.js'
+      );
+      expect(fs.existsSync(testFile)).toBe(true);
+      expect(fs.readFileSync(testFile, 'utf-8')).toContain('/health');
+    });
+
+    it('uses MONGODB_URI in the mongoose config with --db', () => {
+      const mongoose = fs.readFileSync(
+        path.join(generateExpress('dbenvapp', '--db'), 'config', 'mongoose.js'),
+        'utf-8'
+      );
+      expect(mongoose).toContain('process.env.MONGODB_URI');
+    });
+
+    it('does not add the express test scaffolding to node apps', () => {
+      runCLI('nodeplain -f node --skip-install');
+      const pkg = JSON.parse(
+        fs.readFileSync(
+          path.join(testOutput, 'nodeplain', 'package.json'),
+          'utf-8'
+        )
+      );
+      expect(pkg.scripts.test).toBeUndefined();
+      expect(pkg.dependencies.dotenv).toBeUndefined();
+      expect(fs.existsSync(path.join(testOutput, 'nodeplain', 'test'))).toBe(false);
+    });
+  });
 });

--- a/tests/smoke/package.smoke.test.js
+++ b/tests/smoke/package.smoke.test.js
@@ -25,10 +25,10 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 /**
  * GET http://127.0.0.1:<port>/ once and resolve { status, body }.
  */
-const httpGet = (port) =>
+const httpGet = (port, reqPath = '/') =>
   new Promise((resolve, reject) => {
     const req = http.get(
-      { host: '127.0.0.1', port, path: '/', timeout: 2000 },
+      { host: '127.0.0.1', port, path: reqPath, timeout: 2000 },
       (res) => {
         let body = '';
         res.setEncoding('utf-8');
@@ -45,12 +45,12 @@ const httpGet = (port) =>
 /**
  * Retry an HTTP GET with backoff until the server answers or we run out of time.
  */
-const waitForHttp = async (port, deadlineMs = 10000) => {
+const waitForHttp = async (port, reqPath = '/', deadlineMs = 10000) => {
   const start = Date.now();
   let lastErr;
   while (Date.now() - start < deadlineMs) {
     try {
-      return await httpGet(port);
+      return await httpGet(port, reqPath);
     } catch (err) {
       lastErr = err;
       await sleep(250);
@@ -158,8 +158,25 @@ describe('published package smoke test', () => {
       stdio: 'ignore',
     });
 
+  /**
+   * Send `signal` to a running server and resolve with its exit { code, signal }.
+   * Falls back to SIGKILL if it does not exit in time.
+   */
+  const stopProcess = (proc, signal, timeoutMs = 10000) =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        proc.kill('SIGKILL');
+        reject(new Error(`process did not exit within ${timeoutMs}ms`));
+      }, timeoutMs);
+      proc.on('exit', (code, sig) => {
+        clearTimeout(timer);
+        resolve({ code, signal: sig });
+      });
+      proc.kill(signal);
+    });
+
   it(
-    'generates, builds, boots an Express app and serves HTTP 200',
+    'generates, builds, tests, boots an Express app, serves HTTP, and stops cleanly',
     async () => {
       const port = PORTS.express;
       const appDir = generate('smokeexpress', 'express', port);
@@ -170,31 +187,42 @@ describe('published package smoke test', () => {
       expect(fs.existsSync(path.join(appDir, 'routes', 'index.js'))).toBe(true);
       expect(fs.existsSync(path.join(appDir, 'controllers'))).toBe(true);
       expect(fs.existsSync(path.join(appDir, 'model'))).toBe(true);
+      expect(fs.existsSync(path.join(appDir, 'test', 'app.test.js'))).toBe(true);
 
       // A real .gitignore must ship (guards the gitignore fix this branch is on).
       const gitignorePath = path.join(appDir, '.gitignore');
       expect(fs.existsSync(gitignorePath)).toBe(true);
       expect(fs.readFileSync(gitignorePath, 'utf-8').length).toBeGreaterThan(0);
 
-      // Install the generated app's deps (express, cors, ...).
+      // Install the generated app's deps (express, cors, dotenv, supertest, ...).
       execFileSync(npmCmd, ['install', '--no-audit', '--no-fund'], {
         cwd: appDir,
         encoding: 'utf-8',
         timeout: 180000,
       });
 
-      // Boot the server and hit it over HTTP.
+      // The generated app's own integration test passes.
+      execFileSync(npmCmd, ['test'], {
+        cwd: appDir,
+        encoding: 'utf-8',
+        timeout: 120000,
+      });
+
+      // Boot the server and exercise it over HTTP.
       child = startServer(appDir, port);
-      try {
-        const res = await waitForHttp(port);
-        expect(res.status).toBe(200);
-        expect(res.body).toContain('Welcome to ServerGen!');
-      } finally {
-        if (child && !child.killed) {
-          child.kill('SIGKILL');
-        }
-        child = undefined;
-      }
+      const root = await waitForHttp(port, '/');
+      expect(root.status).toBe(200);
+      expect(root.body).toContain('Welcome to ServerGen!');
+
+      const health = await httpGet(port, '/health');
+      expect(health.status).toBe(200);
+      expect(health.body).toContain('"status":"ok"');
+
+      // The server shuts down cleanly on SIGTERM (exit 0, not killed by signal).
+      const { code, signal } = await stopProcess(child, 'SIGTERM');
+      child = undefined;
+      expect(signal).toBeNull();
+      expect(code).toBe(0);
     },
     240000
   );


### PR DESCRIPTION
# Problem & Solution Overview

Generated Express apps are now production-ready:
- Load `.env` via dotenv, and the mongoose config uses `MONGODB_URI` (falling back to a local DB).
- A `/health` endpoint returning `{ status: 'ok' }`.
- Centralized error-handling middleware.
- Graceful shutdown on `SIGINT`/`SIGTERM` (closes the server, and the Mongo connection for `--db`).
- Binds to `0.0.0.0` so it works in Docker.
- `start`, `dev`, and `test` scripts.
- The app is exported (and only listens when run directly), so it ships with a basic integration test (`node --test` + supertest) hitting `/health` and `/`.

These apply to the Express templates only; Node apps are unchanged.

# Testing Done

- `npm test`: 231 passing (8 new integration tests covering the health endpoint, dotenv/export, 0.0.0.0 + signal handlers, error middleware, the start/dev/test scripts + supertest, the generated test file, `MONGODB_URI`, and that node apps don't get the express scaffolding).
- `npm run test:package` (release smoke): from the installed tarball, generates an Express app, installs it, runs the generated app's own `npm test`, boots it, asserts 200 on `/` and `/health`, and confirms a clean exit-0 shutdown on `SIGTERM`.
- Verified the full lifecycle locally end to end (install, generated `npm test` 2/2, `/health` 200, graceful SIGTERM).
