### PR TITLE
chore: move active release line to 2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@latest
 
-      # Explicit --tag latest: an old 2.0.0 exists on the registry, so npm will
-      # not implicitly move the latest tag onto the lower (but newer) 1.3.0.
+      # Explicit --tag latest: 2.1.0+ is the active release line and supersedes
+      # the historical 2021 servergen@2.0.0 package on the npm registry.
       - name: Publish to npm
         run: npm publish --tag latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.1.0 - Unreleased
+
+- Move the active npm release line from `1.4.0` to `2.1.0` so the next publish sorts after the historical `servergen@2.0.0` from 2021.
+- Treat `2.1.0` as the active successor to the 2026 `1.x` line; it intentionally supersedes the old 2021 `2.0.0` package.
+- Keep publishing with the `latest` dist-tag, and deprecate `servergen@2.0.0` after `2.1.0` is available on npm.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servergen",
-  "version": "1.4.0",
+  "version": "2.1.0",
   "description": "CLI that scaffolds production-ready Node.js and Express apps with MVC structure, optional view engines, MongoDB, and Docker support.",
   "type": "module",
   "main": "./index.js",
@@ -10,6 +10,7 @@
     "index.js",
     "templates",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package version to 2.1.0 so the active line sorts after the historical 2021 servergen@2.0.0
- include CHANGELOG.md in the npm files allowlist
- document the 2.1.0 version strategy and update the release workflow comment

## Testing
- npm view servergen name version versions time dist-tags --json
- npm test
- npm run test:package
- npm pack --dry-run --json

## Follow-up
After 2.1.0 is published, run:

```sh
npm deprecate servergen@2.0.0 "servergen@2.0.0 is an abandoned 2021 release. Use servergen@2.1.0 or later; 2.1.0 supersedes it as the active line."
```