### PR TITLE
fix: preserve hyphenated app names

### DIFF
--- a/lib/fileName.js
+++ b/lib/fileName.js
@@ -4,11 +4,15 @@
  */
 
 /**
- * Sanitizes the application name by converting to lowercase
- * and removing all non-alphanumeric characters.
+ * Sanitizes the application name by converting to lowercase,
+ * preserving single hyphen separators, and removing unsafe path characters.
  * @param {string} str - The raw application name input.
  * @returns {string} The sanitized application name.
  */
 export const cleanAppName = (str) => {
-  return str.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
 };

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -221,7 +221,21 @@ describe('CLI Integration', () => {
 
     it('sanitizes the positional name', () => {
       runCLI('My-Api --skip-install');
-      expect(fs.existsSync(path.join(testOutput, 'myapi', 'index.js'))).toBe(true);
+      const appDir = path.join(testOutput, 'my-api');
+      expect(fs.existsSync(path.join(appDir, 'index.js'))).toBe(true);
+
+      const pkg = JSON.parse(fs.readFileSync(path.join(appDir, 'package.json'), 'utf-8'));
+      expect(pkg.name).toBe('my-api');
+    });
+
+    it('keeps path-like names inside the current working directory', () => {
+      const outsideName = `escape-${path.basename(testOutput)}`;
+      const appName = outsideName.toLowerCase();
+      runCLI(`../${outsideName} --skip-install`);
+
+      expect(fs.existsSync(path.join(testOutput, appName, 'index.js'))).toBe(true);
+      expect(fs.existsSync(path.join(path.dirname(testOutput), outsideName))).toBe(false);
+      expect(fs.existsSync(path.join(path.dirname(testOutput), appName))).toBe(false);
     });
 
     it('accepts the same name supplied both ways', () => {

--- a/tests/integration/packaged.test.js
+++ b/tests/integration/packaged.test.js
@@ -86,8 +86,7 @@ describe('packaged CLI (from npm tarball)', () => {
   }, 120000);
 
   it('ships a real .gitignore in a generated node app', () => {
-    // Names are sanitized to [a-z0-9] by the CLI, so avoid hyphens here.
-    const appDir = generateFromTarball('packtestnode', 'node');
+    const appDir = generateFromTarball('pack-test-node', 'node');
 
     const gitignorePath = path.join(appDir, '.gitignore');
     expect(fs.existsSync(gitignorePath)).toBe(true);

--- a/tests/unit/fileName.test.js
+++ b/tests/unit/fileName.test.js
@@ -6,16 +6,24 @@ describe('cleanAppName', () => {
     expect(cleanAppName('MyApp')).toBe('myapp');
   });
 
-  it('removes spaces', () => {
-    expect(cleanAppName('my app')).toBe('myapp');
+  it('preserves single hyphen separators', () => {
+    expect(cleanAppName('demo-express')).toBe('demo-express');
   });
 
-  it('removes special characters', () => {
-    expect(cleanAppName('my-app_test!@#')).toBe('myapptest');
+  it('normalizes uppercase hyphenated names', () => {
+    expect(cleanAppName('My-Api')).toBe('my-api');
   });
 
-  it('removes hyphens and underscores', () => {
-    expect(cleanAppName('my-app_name')).toBe('myappname');
+  it('collapses spaces and unsafe punctuation into single hyphens', () => {
+    expect(cleanAppName('my app_test!@#demo')).toBe('my-app-test-demo');
+  });
+
+  it('collapses repeated hyphens', () => {
+    expect(cleanAppName('my---app')).toBe('my-app');
+  });
+
+  it('removes leading and trailing hyphens from unsafe input', () => {
+    expect(cleanAppName('../My-App/')).toBe('my-app');
   });
 
   it('handles numbers', () => {


### PR DESCRIPTION
## Summary
- preserve valid internal hyphens in generated app names
- collapse unsafe punctuation and path separators into single hyphen separators
- add unit and integration coverage for hyphenated and path-like names

## Testing
- npm test -- tests/unit/fileName.test.js tests/integration/integration.test.js
- npm test